### PR TITLE
Add change directory to bosh-lite

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ This readme walks through deploying Cloud Foundry with BOSH Lite. BOSH and BOSH 
     ```
     $ cd ~/workspace
     $ git clone https://github.com/cloudfoundry/bosh-lite
+    $ cd bosh-lite
     ```
 
 ### Install and Boot a Virtual Machine


### PR DESCRIPTION
It is necessary to cd into the bosh lite directory for the the rest of the commands to work.
